### PR TITLE
Fix README and wallet loop; add unit test

### DIFF
--- a/NewBurnAlertBot.py
+++ b/NewBurnAlertBot.py
@@ -132,49 +132,49 @@ def monitor_wallets():
                     blockchain = wallet_blockchain
                     transactions = get_wallet_transactions(wallet_address, token_address, blockchain)
 
-                for tx in transactions:
-                    if blockchain == 'pls':
-                        tx_hash = tx['blockHash']
-                    else:
-                        tx_hash = tx['hash']
-                    tx_time = int(tx['timeStamp'])
-                    if blockchain == 'eth':
-                        price = eth_usd_price
-                        token = 'ETH'
-                    elif blockchain == "eth":
-                        price = dai_usd_price
-                        token = 'DAI'
-                    elif blockchain == "eth":
-                        price = link_usd_price
-                        token = 'LINK'
-                    elif blockchain == "eth":
-                        price = usdc_usd_price
-                        token = 'USDC'
-                    elif blockchain == "eth":
-                        price = usdt_usd_price
-                        token = 'USDT'
-                 
-                    elif blockchain == "pls":
-                        price = pls_usd_price
-                        token = 'PLS'
-                 
-                    else:
-                        raise ValueError('Invalid blockchain specified')
-                        
-                    if tx_hash not in latest_tx_hashes and tx_time > last_run_time:
-                        if tx['to'].lower() == wallet_address.lower():
-                            value = float(tx['value']) / 10 ** 18  # Convert from wei to ETH or BNB
-                            usd_value = value * price  # Calculate value in USD
-                            message = f'🚨 Incoming transaction detected on {wallet_address}'
-                            send_telegram_notification(message, value, usd_value, tx['hash'], blockchain,tx['from'],tx['to'], tx['tokenSymbol'])
-                            latest_tx_hashes[tx_hash] = int(tx['blockNumber'])
+                    for tx in transactions:
+                        if blockchain == 'pls':
+                            tx_hash = tx['blockHash']
+                        else:
+                            tx_hash = tx['hash']
+                        tx_time = int(tx['timeStamp'])
+                        if blockchain == 'eth':
+                            price = eth_usd_price
+                            token = 'ETH'
+                        elif blockchain == "eth":
+                            price = dai_usd_price
+                            token = 'DAI'
+                        elif blockchain == "eth":
+                            price = link_usd_price
+                            token = 'LINK'
+                        elif blockchain == "eth":
+                            price = usdc_usd_price
+                            token = 'USDC'
+                        elif blockchain == "eth":
+                            price = usdt_usd_price
+                            token = 'USDT'
 
-                        elif tx['from'].lower() == token_address.lower():
-                            value = float(tx['value']) / 10 ** 18  # Convert from wei to ETH or BNB
-                            usd_value = value * price  # Calculate value in USD
-                            message = f'🚨 Outgoing transaction detected on {token_address}'
-                            send_telegram_notification(message, value, usd_value, tx['hash'], blockchain,tx['from'],tx['to'], tx['tokenSymbol'])
-                            latest_tx_hashes[tx_hash] = int(tx['blockNumber'])
+                        elif blockchain == "pls":
+                            price = pls_usd_price
+                            token = 'PLS'
+
+                        else:
+                            raise ValueError('Invalid blockchain specified')
+
+                        if tx_hash not in latest_tx_hashes and tx_time > last_run_time:
+                            if tx['to'].lower() == wallet_address.lower():
+                                value = float(tx['value']) / 10 ** 18  # Convert from wei to ETH or BNB
+                                usd_value = value * price  # Calculate value in USD
+                                message = f'🚨 Incoming transaction detected on {wallet_address}'
+                                send_telegram_notification(message, value, usd_value, tx['hash'], blockchain,tx['from'],tx['to'], tx['tokenSymbol'])
+                                latest_tx_hashes[tx_hash] = int(tx['blockNumber'])
+
+                            elif tx['from'].lower() == token_address.lower():
+                                value = float(tx['value']) / 10 ** 18  # Convert from wei to ETH or BNB
+                                usd_value = value * price  # Calculate value in USD
+                                message = f'🚨 Outgoing transaction detected on {token_address}'
+                                send_telegram_notification(message, value, usd_value, tx['hash'], blockchain,tx['from'],tx['to'], tx['tokenSymbol'])
+                                latest_tx_hashes[tx_hash] = int(tx['blockNumber'])
 
 
                   

--- a/burnBot.py
+++ b/burnBot.py
@@ -132,49 +132,49 @@ def monitor_wallets():
                     blockchain = wallet_blockchain
                     transactions = get_wallet_transactions(wallet_address, token_address, blockchain)
 
-                for tx in transactions:
-                    if blockchain == 'pls':
-                        tx_hash = tx['blockHash']
-                    else:
-                        tx_hash = tx['hash']
-                    tx_time = int(tx['timeStamp'])
-                    if blockchain == 'eth':
-                        price = eth_usd_price
-                        token = 'ETH'
-                    elif blockchain == "eth":
-                        price = dai_usd_price
-                        token = 'DAI'
-                    elif blockchain == "eth":
-                        price = link_usd_price
-                        token = 'LINK'
-                    elif blockchain == "eth":
-                        price = usdc_usd_price
-                        token = 'USDC'
-                    elif blockchain == "eth":
-                        price = usdt_usd_price
-                        token = 'USDT'
-                 
-                    elif blockchain == "pls":
-                        price = pls_usd_price
-                        token = 'PLS'
-                 
-                    else:
-                        raise ValueError('Invalid blockchain specified')
-                        
-                    if tx_hash not in latest_tx_hashes and tx_time > last_run_time:
-                        if tx['to'].lower() == wallet_address.lower():
-                            value = float(tx['value']) / 10 ** 18  # Convert from wei to ETH or BNB
-                            usd_value = value * price  # Calculate value in USD
-                            message = f'🚨 Incoming transaction detected on {wallet_address}'
-                            send_telegram_notification(message, value, usd_value, tx['hash'], blockchain,tx['from'],tx['to'], tx['tokenSymbol'])
-                            latest_tx_hashes[tx_hash] = int(tx['blockNumber'])
+                    for tx in transactions:
+                        if blockchain == 'pls':
+                            tx_hash = tx['blockHash']
+                        else:
+                            tx_hash = tx['hash']
+                        tx_time = int(tx['timeStamp'])
+                        if blockchain == 'eth':
+                            price = eth_usd_price
+                            token = 'ETH'
+                        elif blockchain == "eth":
+                            price = dai_usd_price
+                            token = 'DAI'
+                        elif blockchain == "eth":
+                            price = link_usd_price
+                            token = 'LINK'
+                        elif blockchain == "eth":
+                            price = usdc_usd_price
+                            token = 'USDC'
+                        elif blockchain == "eth":
+                            price = usdt_usd_price
+                            token = 'USDT'
 
-                        elif tx['from'].lower() == token_address.lower():
-                            value = float(tx['value']) / 10 ** 18  # Convert from wei to ETH or BNB
-                            usd_value = value * price  # Calculate value in USD
-                            message = f'🚨 Outgoing transaction detected on {token_address}'
-                            send_telegram_notification(message, value, usd_value, tx['hash'], blockchain,tx['from'],tx['to'], tx['tokenSymbol'])
-                            latest_tx_hashes[tx_hash] = int(tx['blockNumber'])
+                        elif blockchain == "pls":
+                            price = pls_usd_price
+                            token = 'PLS'
+
+                        else:
+                            raise ValueError('Invalid blockchain specified')
+
+                        if tx_hash not in latest_tx_hashes and tx_time > last_run_time:
+                            if tx['to'].lower() == wallet_address.lower():
+                                value = float(tx['value']) / 10 ** 18  # Convert from wei to ETH or BNB
+                                usd_value = value * price  # Calculate value in USD
+                                message = f'🚨 Incoming transaction detected on {wallet_address}'
+                                send_telegram_notification(message, value, usd_value, tx['hash'], blockchain,tx['from'],tx['to'], tx['tokenSymbol'])
+                                latest_tx_hashes[tx_hash] = int(tx['blockNumber'])
+
+                            elif tx['from'].lower() == token_address.lower():
+                                value = float(tx['value']) / 10 ** 18  # Convert from wei to ETH or BNB
+                                usd_value = value * price  # Calculate value in USD
+                                message = f'🚨 Outgoing transaction detected on {token_address}'
+                                send_telegram_notification(message, value, usd_value, tx['hash'], blockchain,tx['from'],tx['to'], tx['tokenSymbol'])
+                                latest_tx_hashes[tx_hash] = int(tx['blockNumber'])
 
 
                   

--- a/readme.md
+++ b/readme.md
@@ -10,10 +10,6 @@ Run the following commands to install the required libraries (requests, web3, an
 ```bash
 pip install requests
 pip install web3
-pip install json
-pip install time
-pip install os.path
-pip install re
 pip install python-telegram-bot
 
 ```
@@ -29,7 +25,7 @@ Step 4: Update the script
 Replace the placeholder BOT_TOKEN in the script with the token provided by the BotFather. Also, replace '@yaratoken' with the actual Telegram group ID where you want to send the alert messages. and add the etherscan API key
 
 Step 5: Run the script
-Now, you are ready to run the script.  and execute it:
+Now you are ready to run the script. Execute it with:
 
 ```bash
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch
+import sys
+import types
+import ast
+
+# Dynamically load the get_wallet_transactions function without executing the full script
+with open('burnBot.py', 'r') as f:
+    tree = ast.parse(f.read(), filename='burnBot.py')
+for node in tree.body:
+    if isinstance(node, ast.FunctionDef) and node.name == 'get_wallet_transactions':
+        func_code = ast.Module([node], [])
+        ns = {}
+        exec(compile(func_code, 'burnBot.py', 'exec'), ns)
+        get_wallet_transactions = ns['get_wallet_transactions']
+        break
+
+# Provide stub modules for external dependencies
+requests_stub = types.ModuleType('requests')
+requests_stub.get = lambda *args, **kwargs: None
+sys.modules.setdefault('requests', requests_stub)
+
+class TestGetWalletTransactions(unittest.TestCase):
+    def test_invalid_blockchain_raises(self):
+        with patch('requests.get') as mock_get:
+            with self.assertRaises(ValueError):
+                get_wallet_transactions('0x0', '0x0', 'btc')
+            mock_get.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix instructions in the README
- fix wallet/token loop so each wallet iterates over its tokens
- update the same logic in `NewBurnAlertBot.py`
- add tests for invalid blockchain handling in `get_wallet_transactions`

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6859764fccd08332b1948414740f5df8